### PR TITLE
rewrite arg parsing using click (#17)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ help:
 
 .PHONY: clean
 clean:  ## Clean build artifacts
-	rm -rf build dist ${PROJECT}.egg-info .tox
+	rm -rf build dist ${PROJECT}.egg-info .tox .pytest-cache
 	rm -rf docs/_build/*
 	find ${PROJECT}/ tests/ -name __pycache__ | xargs rm -rf
 	find ${PROJECT}/ tests/ -name '*.pyc' | xargs rm -rf

--- a/crashstats_tools/cmd_reprocess.py
+++ b/crashstats_tools/cmd_reprocess.py
@@ -2,121 +2,118 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import argparse
 import os
+import sys
 import time
 
+import click
 from more_itertools import chunked
 
-from crashstats_tools.utils import (
-    DEFAULT_HOST,
-    FallbackToPipeAction,
-    http_post,
-    parse_crashid,
-    WrappedTextHelpFormatter,
-)
-
-
-DESCRIPTION = """
-Sends specified crashes for reprocessing
-
-This requires CRASHSTATS_API_TOKEN to be set in the environment to a valid API
-token.
-
-Note: If you're processing more than 10,000 crashes, you should use a sleep
-value that balances the rate of crash ids being added to the queue and the
-rate of crash ids being processed. For example, you could use "--sleep 10"
-which will sleep for 10 seconds between submitting groups of crashes.
-
-Also, if you're processing a lot of crashes, you should let us know before you
-do it.
-
-"""
+from crashstats_tools.utils import DEFAULT_HOST, http_post, parse_crashid
 
 
 CHUNK_SIZE = 50
 SLEEP_DEFAULT = 1
 
 
-def main(argv=None):
-    parser = argparse.ArgumentParser(
-        formatter_class=WrappedTextHelpFormatter, description=DESCRIPTION.strip()
-    )
-    parser.add_argument(
-        "--host", help="host for system to reprocess in", default=DEFAULT_HOST
-    )
-    parser.add_argument(
-        "--sleep",
-        help="how long in seconds to sleep before submitting the next group",
-        type=int,
-        default=SLEEP_DEFAULT,
-    )
-    parser.add_argument(
-        "--allowmany",
-        action="store_true",
-        help=(
-            "don't prompt user about letting us know about reprocessing "
-            "more than 10,000 crashes"
-        ),
-    )
-    parser.add_argument(
-        "crashid",
-        help="one or more crash ids to fetch data for",
-        nargs="*",
-        action=FallbackToPipeAction,
-    )
+@click.command()
+@click.option(
+    "--host",
+    default=DEFAULT_HOST,
+    show_default=True,
+    help="host for system to reprocess in",
+)
+@click.option(
+    "--sleep",
+    type=int,
+    default=SLEEP_DEFAULT,
+    show_default=True,
+    help="how long in seconds to sleep before submitting the next group",
+)
+@click.option(
+    "--allowmany/--no-allow-many",
+    default=False,
+    help=(
+        "don't prompt user about letting us know about reprocessing "
+        "more than 10,000 crashes"
+    ),
+)
+@click.argument("crashids", nargs=-1)
+@click.pass_context
+def reprocess(ctx, host, sleep, allowmany, crashids):
+    """
+    Sends specified crashes for reprocessing
 
-    if argv is None:
-        args = parser.parse_args()
-    else:
-        args = parser.parse_args(argv)
+    This requires CRASHSTATS_API_TOKEN to be set in the environment to a valid
+    API token.
 
+    Note: If you're processing more than 10,000 crashes, you should use a sleep
+    value that balances the rate of crash ids being added to the queue and the
+    rate of crash ids being processed. For example, you could use "--sleep 10"
+    which will sleep for 10 seconds between submitting groups of crashes.
+
+    Also, if you're processing a lot of crashes, you should let us know before
+    you do it.
+    """
     api_token = os.environ.get("CRASHSTATS_API_TOKEN")
     if not api_token:
-        print("You need to set CRASHSTATS_API_TOKEN in the environment.")
+        click.echo("You need to set CRASHSTATS_API_TOKEN in the environment.")
         return 1
 
-    url = args.host.rstrip("/") + "/api/Reprocessing/"
-    print("Sending reprocessing requests to: %s" % url)
+    url = host.rstrip("/") + "/api/Reprocessing/"
+    click.echo("Sending reprocessing requests to: %s" % url)
 
-    crashids = [
-        parse_crashid(crashid.strip())
-        for crashid in args.crashid
-    ]
-    if len(crashids) > 10000 and not args.allowmany:
-        print(
+    if not crashids and not sys.stdin.isatty():
+        crashids = list(click.get_text_stream("stdin").readlines())
+
+    crashids = [parse_crashid(crashid.strip()) for crashid in crashids]
+
+    if not crashids:
+        raise click.BadParameter(
+            message="No crashids specified.",
+            ctx=ctx,
+            param="crashids",
+            param_hint="crashids",
+        )
+
+    if len(crashids) > 10000 and not allowmany:
+        click.echo(
             "You are trying to reprocess more than 10,000 crash reports at "
             "once. Please let us know on #breakpad on irc.mozilla.org "
             "before you do this."
         )
-        print("")
-        print("Pass in --allowmany argument.")
-        print("")
-        print("Exiting.")
-        return 1
+        click.echo("")
+        click.echo("Pass in --allowmany argument.")
+        click.echo("")
+        click.echo("Exiting.")
+        ctx.exit(1)
 
-    print(
+    click.echo(
         "Reprocessing %s crashes sleeping %s seconds between groups..."
-        % (len(crashids), args.sleep)
+        % (len(crashids), sleep)
     )
 
     groups = list(chunked(crashids, CHUNK_SIZE))
     for i, group in enumerate(groups):
-        print(
+        if i > 0:
+            # NOTE(willkg): We sleep here because the webapp has a bunch of rate
+            # limiting and we don't want to trigger that. It'd be nice if we didn't
+            # have to do this.
+            time.sleep(sleep)
+
+        click.echo(
             "Processing group ending with %s ... (%s/%s)"
             % (group[-1], i + 1, len(groups))
         )
         resp = http_post(url, data={"crash_ids": group}, api_token=api_token)
         if resp.status_code != 200:
-            print(
+            click.echo(
                 "Got back non-200 status code: %s %s" % (resp.status_code, resp.content)
             )
             continue
 
-        # NOTE(willkg): We sleep here because the webapp has a bunch of rate
-        # limiting and we don't want to trigger that. It'd be nice if we didn't
-        # have to do this.
-        time.sleep(args.sleep)
+    click.echo("Done!")
 
-    print("Done!")
-    return 0
+
+if __name__ == "__main__":
+    reprocess()

--- a/crashstats_tools/cmd_supersearch.py
+++ b/crashstats_tools/cmd_supersearch.py
@@ -2,75 +2,15 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import argparse
 import json
 import logging
 import os
 from urllib.parse import urlparse, parse_qs
 
+import click
 
-from crashstats_tools.utils import (
-    DEFAULT_HOST,
-    http_get,
-    INFINITY,
-    parse_args,
-    WrappedTextHelpFormatter,
-)
+from crashstats_tools.utils import DEFAULT_HOST, http_get, INFINITY, parse_args
 
-
-DESCRIPTION = """
-Fetches data from Crash Stats using Super Search
-
-There are two ways to run this:
-
-First, you can specify Super Search API fields to generate the query.
-
-For example:
-
-$ supersearch --product=Firefox --num=100 --date='>=2019-07-31'
-
-Second, you can pass in a url from a Super Search on Crash Stats. This command
-will then pull out the parameters. You can override those parameters with
-command line arguments.
-
-$ supersearch --supersearch-url='longurlhere' --num=100
-
-Make sure to use single quotes when specifying values so that your shell doesn't
-expand variables.
-
-Returned fields are tab-delimited. You can specify them using the Super Search
-field "_columns".
-
-For example:
-
-$ supersearch --_columns=uuid --_columns=product --_columns=build_id --_columns=version
-
-Results are tab-delimited. Tabs and newlines in output is escaped.
-
-This doesn't support any of the aggregations at this time.
-
-For list of available fields and Super Search API documentation, see:
-
-https://crash-stats.mozilla.org/documentation/supersearch/
-
-https://crash-stats.mozilla.org/documentation/supersearch/api/
-
-This requires an API token in order to download search and download personally
-identifiable information and security-sensitive data. It also reduces
-rate-limiting.  Set the CRASHSTATS_API_TOKEN environment variable to your API
-token value:
-
-    CRASHSTATS_API_TOKEN=xyz fetch-data crashdata ...
-
-To create an API token for Crash Stats, visit:
-
-    https://crash-stats.mozilla.org/api/tokens/
-
-Remember to abide by the data access policy when using data from Crash Stats!
-The policy is specified here:
-
-https://crash-stats.mozilla.org/documentation/memory_dump_access/
-"""
 
 MAX_PAGE = 1000
 
@@ -154,47 +94,103 @@ def extract_supersearch_params(url):
     return params
 
 
-def main(argv=None):
-    parser = argparse.ArgumentParser(
-        formatter_class=WrappedTextHelpFormatter, description=DESCRIPTION.strip()
-    )
-    parser.add_argument(
-        "--host", default=DEFAULT_HOST, help="host for system to fetch crashids from"
-    )
-    parser.add_argument(
-        "--supersearch-url", default="", help="Super Search url to base query on"
-    )
-    parser.add_argument(
-        "--num",
-        default=100,
-        help='number of crash ids you want or "all" for all of them',
-    )
-    parser.add_argument(
-        "--format", default="tab", choices=["tab", "json"], help="format for output"
-    )
-    parser.add_argument(
-        "-v", "--verbose", action="store_true", help="increase verbosity of output"
-    )
+@click.command(
+    context_settings={"allow_extra_args": True, "ignore_unknown_options": True}
+)
+@click.option(
+    "--host",
+    default=DEFAULT_HOST,
+    show_default=True,
+    help="host for system to fetch crashids from",
+)
+@click.option("--supersearch-url", default="", help="Super Search url to base query on")
+@click.option(
+    "--num",
+    default=100,
+    show_default=True,
+    help='number of crash ids you want or "all" for all of them',
+)
+@click.option(
+    "--format",
+    "format_type",
+    default="tab",
+    show_default=True,
+    type=click.Choice(["tab", "json"], case_sensitive=False),
+    help="format to print output",
+)
+@click.option(
+    "--verbose/--no-verbose", default=False, help="whether to print debugging output"
+)
+@click.pass_context
+def supersearch(ctx, host, supersearch_url, num, format_type, verbose):
+    """
+    Fetches data from Crash Stats using Super Search
 
-    if argv is None:
-        args, supersearch_args = parser.parse_known_args()
-    else:
-        args, supersearch_args = parser.parse_known_args(argv)
+    There are two ways to run this:
 
-    if args.verbose:
+    First, you can specify Super Search API fields to generate the query.
+
+    For example:
+
+    $ supersearch --product=Firefox --num=100 --date='>=2019-07-31'
+
+    Second, you can pass in a url from a Super Search on Crash Stats. This command
+    will then pull out the parameters. You can override those parameters with
+    command line arguments.
+
+    $ supersearch --supersearch-url='longurlhere' --num=100
+
+    Make sure to use single quotes when specifying values so that your shell doesn't
+    expand variables.
+
+    Returned fields are tab-delimited. You can specify them using the Super Search
+    field "_columns".
+
+    For example:
+
+    $ supersearch --_columns=uuid --_columns=product --_columns=build_id --_columns=version
+
+    Results are tab-delimited. Tabs and newlines in output is escaped.
+
+    This doesn't support any of the aggregations at this time.
+
+    For list of available fields and Super Search API documentation, see:
+
+    https://crash-stats.mozilla.org/documentation/supersearch/
+
+    https://crash-stats.mozilla.org/documentation/supersearch/api/
+
+    This requires an API token in order to download search and download personally
+    identifiable information and security-sensitive data. It also reduces
+    rate-limiting. Set the CRASHSTATS_API_TOKEN environment variable to your API
+    token value:
+
+    CRASHSTATS_API_TOKEN=xyz supersearch ...
+
+    To create an API token for Crash Stats, visit:
+
+    https://crash-stats.mozilla.org/api/tokens/
+
+    Remember to abide by the data access policy when using data from Crash Stats!
+    The policy is specified here:
+
+    https://crash-stats.mozilla.org/documentation/memory_dump_access/
+    """
+
+    if verbose:
         # Set logging to DEBUG because this picks up debug logging from
         # requests which lets us see urls.
         logging.basicConfig(level=logging.DEBUG)
 
-    host = args.host.rstrip("/")
+    host = host.rstrip("/")
 
     # Start with params from --url value or product=Firefox
-    if args.supersearch_url:
-        params = extract_supersearch_params(args.supersearch_url)
+    if supersearch_url:
+        params = extract_supersearch_params(supersearch_url)
     else:
         params = {}
 
-    params.update(parse_args(supersearch_args))
+    params.update(parse_args(ctx.args))
 
     if "_columns" not in params:
         params["_columns"] = ["uuid"]
@@ -204,7 +200,7 @@ def main(argv=None):
         # user wants the most recent crash reports.
         params["_sort"] = ["-date"]
 
-    num_results = args.num
+    num_results = num
     if num_results == "all":
         num_results = INFINITY
 
@@ -212,32 +208,38 @@ def main(argv=None):
         try:
             num_results = int(num_results)
         except ValueError:
-            print('num needs to be an integer or "all"')
-            return 1
+            raise click.BadOptionUsage(
+                "num", 'num needs to be an integer or "all"', ctx=ctx
+            )
 
-    if args.verbose:
-        print("Params: %s" % params)
+    if verbose:
+        click.echo("Params: %s" % params)
 
     # Sort out API token existence
     api_token = os.environ.get("CRASHSTATS_API_TOKEN")
-    if args.verbose:
+    if verbose:
         if api_token:
-            print("Using api token: %s%s" % (api_token[:4], "x" * (len(api_token) - 4)))
+            click.echo(
+                "Using api token: %s%s" % (api_token[:4], "x" * (len(api_token) - 4))
+            )
         else:
-            print(
+            click.echo(
                 "No api token provided. Skipping dumps and personally identifiable information."
             )
 
     for hit in fetch_supersearch(
-        host, params, num_results, api_token=api_token, verbose=args.verbose
+        host, params, num_results, api_token=api_token, verbose=verbose
     ):
-        if args.format == "tab":
-            print(
+        if format_type == "tab":
+            click.echo(
                 "\t".join(
                     [clean_whitespace(hit[field]) for field in params["_columns"]]
                 )
             )
-        elif args.format == "json":
-            print(json.dumps(hit))
 
-    return 0
+        elif format_type == "json":
+            click.echo(json.dumps(hit))
+
+
+if __name__ == "__main__":
+    supersearch()

--- a/crashstats_tools/utils.py
+++ b/crashstats_tools/utils.py
@@ -2,12 +2,10 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
-import argparse
 import datetime
 from functools import total_ordering
 import json
 import re
-import sys
 from urllib.parse import urlparse
 
 import requests
@@ -30,144 +28,6 @@ class JsonDTEncoder(json.JSONEncoder):
         if isinstance(obj, datetime.datetime):
             return obj.strftime("%Y-%m-%d %H:%M:%S.%f")
         return json.JSONEncoder.default(self, obj)
-
-
-class WrappedTextHelpFormatter(argparse.HelpFormatter):
-    """Subclass that wraps description and epilog text taking paragraphs into account"""
-
-    def _fill_text(self, text, width, indent):
-        """Wraps text like HelpFormatter, but doesn't squash lines
-
-        This makes it easier to do lists and paragraphs.
-
-        """
-        parts = text.split("\n\n")
-        for i, part in enumerate(parts):
-            # Check to see if it's a bulleted list--if so, then fill each line
-            if part.startswith("* "):
-                subparts = part.split("\n")
-                for j, subpart in enumerate(subparts):
-                    subparts[j] = super(WrappedTextHelpFormatter, self)._fill_text(
-                        subpart, width, indent
-                    )
-                parts[i] = "\n".join(subparts)
-            else:
-                parts[i] = super(WrappedTextHelpFormatter, self)._fill_text(
-                    part, width, indent
-                )
-
-        return "\n\n".join(parts)
-
-
-class FlagAction(argparse.Action):
-    """Facilitates --flag, --no-flag arguments
-
-    Usage::
-
-        parser.add_argument(
-            '--flag', '--no-flag', action=FlagAction, default=True,
-            help='whether to enable flag'
-        )
-
-
-    Which allows you to do::
-
-        $ command
-        $ command --flag
-        $ command --no-flag
-
-
-    And the help works nicely, too::
-
-        $ command --help
-        ...
-        optional arguments:
-           --flag, --no-flag  whether to enable flag
-
-    """
-
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        # Validate option strings--we should have a no- option for every option
-        options = [opt.strip("-") for opt in option_strings]
-
-        yes_options = [opt for opt in options if not opt.startswith("no-")]
-        no_options = [opt[3:] for opt in options if opt.startswith("no-")]
-
-        if sorted(yes_options) != sorted(no_options):
-            raise ValueError("There should be one --no option for every option value.")
-
-        super().__init__(option_strings, dest, nargs=0, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        if option_string.startswith("--no"):
-            value = False
-        else:
-            value = True
-        setattr(namespace, self.dest, value)
-
-
-class FallbackToPipeAction(argparse.Action):
-    """Fallback to load strings piped from stdin
-
-    This action reads from stdin when the positional arguments were omitted. It
-    expects one value per line, and at least one value.
-
-    This does not work with named arguments, since the action is not called
-    when a named argument is omitted.
-
-    To use this as a fallback for positional arguments:
-    > parser.add_argument('name', nargs='*', action=FallbackToPipeAction)
-    """
-
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
-        """Initialize the FallbackToPipeAction.
-
-        :param option_strings: Names for non-positional arguments.
-        :param dest: The destination attribute on the parser
-        :param nargs: The number of arguments, must be '*' for zero or more
-        :param kwargs: Additional parameters for the parser argument
-        """
-        if option_strings:
-            raise ValueError("This action does not work with named arguments")
-        if nargs != "*":
-            # For nargs='*', the action is called with an empty list.
-            # For other values ('?', '+', 1), the action isn't called, so we
-            # can't fallback to reading from stdin.
-            raise ValueError("nargs should be '*'")
-        super().__init__(option_strings, dest, nargs=nargs, **kwargs)
-
-    def __call__(self, parser, namespace, values, option_string=None):
-        """Call the FallbackToPipeAction.
-
-        If the arguments were set on the command line, use them. Otherwise,
-        try reading from stdin (the pipe). If a pipe was not provided or was
-        empty, parser.error is called to print usage and exit early.
-
-        :param parser: The argument parser
-        :param namespace: The destination namespace
-        :param values: The parsed values, an empty list if omitted
-        :param option_string: The option name, or None for positional arguments
-        """
-
-        if not values:
-            if sys.stdin.isatty():
-                # There is no data being piped to the script, but instead it
-                # is an interactive TTY. Instead of blocking while waiting
-                # for input, exit on the missing parameter
-                parser.error(
-                    'argument "%s" was omitted and stdin is not a pipe.' % self.dest
-                )
-            else:
-                # Data is being piped to this script. Remove trailing newlines
-                # from reading sys.stdin as line iterator.
-                type_func = self.type or str
-                values = [type_func(item.rstrip()) for item in sys.stdin]
-                if not values:
-                    parser.error(
-                        'argument "%s" was omitted and stdin was empty.' % self.dest
-                    )
-
-        setattr(namespace, self.dest, values)
 
 
 class HTTPAdapterWithTimeout(HTTPAdapter):

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     entry_points="""
         [console_scripts]
         fetch-data=crashstats_tools.cmd_fetch_data:main
-        reprocess=crashstats_tools.cmd_reprocess:main
+        reprocess=crashstats_tools.cmd_reprocess:reprocess
         supersearch=crashstats_tools.cmd_supersearch:main
         supersearchfacet=crashstats_tools.cmd_supersearchfacet:supersearchfacet
     """,

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     python_requires=">=3.6",
     entry_points="""
         [console_scripts]
-        fetch-data=crashstats_tools.cmd_fetch_data:main
+        fetch-data=crashstats_tools.cmd_fetch_data:fetch_data
         reprocess=crashstats_tools.cmd_reprocess:reprocess
         supersearch=crashstats_tools.cmd_supersearch:main
         supersearchfacet=crashstats_tools.cmd_supersearchfacet:supersearchfacet

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         [console_scripts]
         fetch-data=crashstats_tools.cmd_fetch_data:fetch_data
         reprocess=crashstats_tools.cmd_reprocess:reprocess
-        supersearch=crashstats_tools.cmd_supersearch:main
+        supersearch=crashstats_tools.cmd_supersearch:supersearch
         supersearchfacet=crashstats_tools.cmd_supersearchfacet:supersearchfacet
     """,
     classifiers=[

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from click.testing import CliRunner
+
+from crashstats_tools import cmd_fetch_data
+
+
+def test_it_runs():
+    runner = CliRunner()
+    result = runner.invoke(cmd_fetch_data.fetch_data, ["--help"])
+    assert result.exit_code == 0

--- a/tests/test_reprocess.py
+++ b/tests/test_reprocess.py
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from click.testing import CliRunner
+
+from crashstats_tools import cmd_reprocess
+
+
+def test_it_runs():
+    runner = CliRunner()
+    result = runner.invoke(cmd_reprocess.reprocess, ["--help"])
+    assert result.exit_code == 0

--- a/tests/test_supersearch.py
+++ b/tests/test_supersearch.py
@@ -1,0 +1,13 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+from click.testing import CliRunner
+
+from crashstats_tools import cmd_supersearch
+
+
+def test_it_runs():
+    runner = CliRunner()
+    result = runner.invoke(cmd_supersearch.supersearch, ["--help"])
+    assert result.exit_code == 0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -4,11 +4,7 @@
 
 import pytest
 
-from crashstats_tools.utils import (
-    is_crash_id_valid,
-    parse_args,
-    parse_crashid,
-)
+from crashstats_tools.utils import is_crash_id_valid, parse_args, parse_crashid
 
 
 @pytest.mark.parametrize(
@@ -26,12 +22,15 @@ def test_validate_crash_id(crashid, expected):
     assert is_crash_id_valid(crashid) == expected
 
 
-@pytest.mark.parametrize("args, expected", [
-    ([], {}),
-    (["--foo", "bar"], {"foo": ["bar"]}),
-    (["--foo=bar"], {"foo": ["bar"]}),
-    (["--foo=bar1", "--foo=bar2"], {"foo": ["bar1", "bar2"]}),
-])
+@pytest.mark.parametrize(
+    "args, expected",
+    [
+        ([], {}),
+        (["--foo", "bar"], {"foo": ["bar"]}),
+        (["--foo=bar"], {"foo": ["bar"]}),
+        (["--foo=bar1", "--foo=bar2"], {"foo": ["bar1", "bar2"]}),
+    ],
+)
 def test_parse_args(args, expected):
     assert parse_args(args) == expected
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,4 +7,3 @@ commands =
     flake8
     black --check
     pytest
-    supersearch --help

--- a/tox.ini
+++ b/tox.ini
@@ -8,5 +8,4 @@ commands =
     black --check
     pytest
     fetch-data --help
-    reprocess --help
     supersearch --help

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,4 @@ commands =
     flake8
     black --check
     pytest
-    fetch-data --help
     supersearch --help


### PR DESCRIPTION
This rewrites all the commands to use click for arg parsing. This also adds basic tests for all commands and removes the "cmd --help" invocation in tox.

Fixes #17.