### PR TITLE
Fix non-string sorting

### DIFF
--- a/src/crashstats_tools/utils.py
+++ b/src/crashstats_tools/utils.py
@@ -335,8 +335,8 @@ def tableize_markdown(headers, rows, show_headers=True):
     """
     output = []
     if show_headers:
-        output.append(" | ".join(headers))
-        output.append(" | ".join(["-" * len(item) for item in headers]))
+        output.append(" | ".join([str(header) for header in headers]))
+        output.append(" | ".join(["-" * len(str(item)) for item in headers]))
     for row in rows:
         output.append(
             " | ".join([clean_pipes(clean_whitespace(str(item))) for item in row])


### PR DESCRIPTION
When I added the "--" thing (which is incredibly helpful), I didn't take
into account that not all values are strings. When the values aren't
strings (for example, application_build_id values), then it would kick
up an error when trying to sort things.

This adds an AlwaysFirst class which we use to smooth over sorting "--"
value with other things. It also guarantees it always shows up first in
the list.