### PR TITLE
Rework output for supersearch and supersearchfacet (#39)

### DIFF
--- a/src/crashstats_tools/utils.py
+++ b/src/crashstats_tools/utils.py
@@ -6,6 +6,7 @@ import datetime
 from functools import total_ordering
 import json
 import re
+from typing import Any, Dict, Generator, Iterable, List
 from urllib.parse import urlparse
 
 import requests
@@ -308,41 +309,43 @@ def parse_crashid(item):
     raise ValueError(f"Not a valid crash id: {item}")
 
 
-def tableize_tab(headers, rows, show_headers=True):
+def tableize_tab(
+    headers: List[str], data: Iterable[Dict[str, Any]], show_headers: bool = True
+) -> Generator[str, None, None]:
     """Generate output for a table using tab delimiters.
 
-    :param list-of-str headers: headers of the table
-    :param list-of-str rows: rows of the table
+    :param headers: headers of the table
+    :param data: rows of the table
 
-    :returns: string
+    :returns: generator of strings
 
     """
-    output = []
     if show_headers:
-        output.append("\t".join([escape_whitespace(str(item)) for item in headers]))
-    for row in rows:
-        output.append("\t".join([escape_whitespace(str(item)) for item in row]))
-    return "\n".join(output)
+        yield "\t".join([escape_whitespace(str(item)) for item in headers])
+
+    for item in data:
+        row = [item[field] for field in headers]
+        yield "\t".join([escape_whitespace(str(item)) for item in row])
 
 
-def tableize_markdown(headers, rows, show_headers=True):
+def tableize_markdown(
+    headers: List[str], data: Iterable[Dict[str, Any]], show_headers: bool = True
+) -> Generator[str, None, None]:
     """Generate output for a table using markdown.
 
-    :param list-of-str headers: headers of the table
-    :param list-of-str rows: rows of the table
+    :param headers: headers of the table
+    :param data: rows of the table
 
-    :returns: string
+    :returns: generator of strings
 
     """
-    output = []
     if show_headers:
-        output.append(" | ".join([str(header) for header in headers]))
-        output.append(" | ".join(["-" * len(str(item)) for item in headers]))
-    for row in rows:
-        output.append(
-            " | ".join([escape_pipes(escape_whitespace(str(item))) for item in row])
-        )
-    return "\n".join(output)
+        yield " | ".join([str(header) for header in headers])
+        yield " | ".join(["-" * len(str(item)) for item in headers])
+
+    for item in data:
+        row = [item[field] for field in headers]
+        yield " | ".join([escape_pipes(escape_whitespace(str(item))) for item in row])
 
 
 RELATIVE_RE = re.compile(r"(\d+)([hdw])", re.IGNORECASE)

--- a/tests/test_supersearchfacet.py
+++ b/tests/test_supersearchfacet.py
@@ -411,21 +411,20 @@ def test_json():
     assert result.exit_code == 0
     assert result.output == dedent(
         """\
-        {
-          "total": 19,
-          "facets": {
-            "product": [
-              {
-                "term": "Firefox",
-                "count": 5
-              },
-              {
-                "term": "Fenix",
-                "count": 4
-              }
-            ]
+        [
+          {
+            "product": "Firefox",
+            "count": 5
+          },
+          {
+            "product": "Fenix",
+            "count": 4
+          },
+          {
+            "product": "--",
+            "count": 10
           }
-        }
+        ]
         """
     )
 
@@ -598,30 +597,32 @@ def test_period_daily():
     assert result.exit_code == 0
     assert result.output == dedent(
         """\
-        {
-          "product": {
-            "2022-06-28 00:00:00": {
-              "Firefox": 5,
-              "Fenix": 4,
-              "--": 10
-            },
-            "2022-06-29 00:00:00": {
-              "Firefox": 4,
-              "Fenix": 4,
-              "--": 10
-            },
-            "2022-06-30 00:00:00": {
-              "Firefox": 6,
-              "Fenix": 3,
-              "--": 10
-            },
-            "2022-07-01 00:00:00": {
-              "Firefox": 7,
-              "Fenix": 3,
-              "--": 12
-            }
+        [
+          {
+            "date": "2022-06-28 00:00:00",
+            "--": 10,
+            "Fenix": 4,
+            "Firefox": 5
+          },
+          {
+            "date": "2022-06-29 00:00:00",
+            "--": 10,
+            "Fenix": 4,
+            "Firefox": 4
+          },
+          {
+            "date": "2022-06-30 00:00:00",
+            "--": 10,
+            "Fenix": 3,
+            "Firefox": 6
+          },
+          {
+            "date": "2022-07-01 00:00:00",
+            "--": 12,
+            "Fenix": 3,
+            "Firefox": 7
           }
-        }
+        ]
         """
     )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -142,83 +142,94 @@ def test_infinity_rhs_subtraction():
 
 
 @pytest.mark.parametrize(
-    "headers, rows, show_headers, expected",
+    "headers, records, show_headers, expected",
     [
         (
             ["abc", "def"],
-            [["1", "foo"], ["2", "bar"]],
+            [{"abc": "1", "def": "foo"}, {"abc": "2", "def": "bar"}],
             True,
             "abc\tdef\n1\tfoo\n2\tbar",
         ),
         (
             ["abc", "def"],
-            [["1", "foo"], ["2", "bar"]],
+            [{"abc": "1", "def": "foo"}, {"abc": "2", "def": "bar"}],
             False,
             "1\tfoo\n2\tbar",
         ),
         # Test stringifying ints and floats
         (
             ["abc", "def", "ghi"],
-            [[1, "foo", 5.5], [2, "bar", 7.5]],
+            [
+                {"abc": 1, "def": "foo", "ghi": 5.5},
+                {"abc": 2, "def": "bar", "ghi": 7.5},
+            ],
             True,
             "abc\tdef\tghi\n1\tfoo\t5.5\n2\tbar\t7.5",
         ),
         # Test whitespace escaping
         (
             ["abc", "def"],
-            [["1", "foo\tjoe\r\njam"], ["2", "bar"]],
+            [{"abc": "1", "def": "foo\tjoe\r\njam"}, {"abc": "2", "def": "bar"}],
             True,
             "abc\tdef\n1\tfoo\\tjoe\\r\\njam\n2\tbar",
         ),
     ],
 )
-def test_tableize_tab(headers, rows, show_headers, expected):
+def test_tableize_tab(headers, records, show_headers, expected):
     assert (
-        tableize_tab(headers=headers, rows=rows, show_headers=show_headers) == expected
+        "\n".join(
+            tableize_tab(headers=headers, data=records, show_headers=show_headers)
+        )
+        == expected
     )
 
 
 @pytest.mark.parametrize(
-    "headers, rows, show_headers, expected",
+    "headers, records, show_headers, expected",
     [
         (
             ["abc", "def"],
-            [["1", "foo"], ["2", "bar"]],
+            [{"abc": "1", "def": "foo"}, {"abc": "2", "def": "bar"}],
             True,
             "abc | def\n--- | ---\n1 | foo\n2 | bar",
         ),
         (
             ["abc", "def"],
-            [["1", "foo"], ["2", "bar"]],
+            [{"abc": "1", "def": "foo"}, {"abc": "2", "def": "bar"}],
             False,
             "1 | foo\n2 | bar",
         ),
         # Test stringifying ints and floats
         (
             ["abc", "def", "ghi"],
-            [[1, "foo", 5.5], [2, "bar", 7.5]],
+            [
+                {"abc": 1, "def": "foo", "ghi": 5.5},
+                {"abc": 2, "def": "bar", "ghi": 7.5},
+            ],
             True,
             "abc | def | ghi\n--- | --- | ---\n1 | foo | 5.5\n2 | bar | 7.5",
         ),
         # Test whitespace escaping
         (
             ["abc", "def"],
-            [["1", "foo\tjoe\r\njam"], ["2", "bar"]],
+            [{"abc": "1", "def": "foo\tjoe\r\njam"}, {"abc": "2", "def": "bar"}],
             True,
             "abc | def\n--- | ---\n1 | foo\\tjoe\\r\\njam\n2 | bar",
         ),
         # Test pipe escaping
         (
             ["abc", "def"],
-            [["1", "foo|bat"], ["2", "bar"]],
+            [{"abc": "1", "def": "foo|bat"}, {"abc": "2", "def": "bar"}],
             True,
             "abc | def\n--- | ---\n1 | foo\\|bat\n2 | bar",
         ),
     ],
 )
-def test_tableize_markdown(headers, rows, show_headers, expected):
+def test_tableize_markdown(headers, records, show_headers, expected):
     assert (
-        tableize_markdown(headers=headers, rows=rows, show_headers=show_headers)
+        "\n".join(
+            tableize_markdown(headers=headers, data=records, show_headers=show_headers)
+        )
         == expected
     )
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ python =
 [testenv]
 deps = -rrequirements-dev.txt
 commands = 
-    pytest
+    pytest {posargs}
 
 [testenv:py37-lint]
 basepython = python3.7


### PR DESCRIPTION
This reworks the output for `supersearch` and `supersearchfacet` so that `format=tab` can stream as results are coming in. This is helpful for incremental progress when using it with pipes.

While doing this, I redid parts of `supersearchfacet` so that it only supports a single `_facet` and if none are specified, it uses the default that Super Search does which is signature.

I also fixed json output to spit out the records including the `--` which covers remaining count.

I also fixed tox to pass `{posargs}` to pytest making it easier to debug specific test cases.

Fixes #39.