### PR TITLE
Fix exception when user doesn't have access to data (#61)

### DIFF
--- a/src/crashstats_tools/cmd_supersearch.py
+++ b/src/crashstats_tools/cmd_supersearch.py
@@ -268,7 +268,10 @@ def supersearch(ctx, host, supersearch_url, num, headers, format_type, verbose, 
             table.add_column(column, justify="left")
         for hit in hits:
             table.add_row(
-                *[escape_whitespace(hit[field]) for field in params["_columns"]]
+                *[
+                    escape_whitespace(hit.get(field, "<no data>"))
+                    for field in params["_columns"]
+                ]
             )
 
         console.print(table)
@@ -289,7 +292,10 @@ def supersearch(ctx, host, supersearch_url, num, headers, format_type, verbose, 
         records = []
         for hit in hits:
             records.append(
-                {field: escape_whitespace(hit[field]) for field in params["_columns"]}
+                {
+                    field: escape_whitespace(hit.get(field, "<no data>"))
+                    for field in params["_columns"]
+                }
             )
         console.print_json(json.dumps(records))
 

--- a/src/crashstats_tools/utils.py
+++ b/src/crashstats_tools/utils.py
@@ -324,8 +324,8 @@ def tableize_tab(
         yield "\t".join([escape_whitespace(str(item)) for item in headers])
 
     for item in data:
-        row = [item[field] for field in headers]
-        yield "\t".join([escape_whitespace(str(item)) for item in row])
+        row = [escape_whitespace(str(item.get(field, ""))) for field in headers]
+        yield "\t".join(row) or "<no data>"
 
 
 def tableize_markdown(
@@ -344,8 +344,11 @@ def tableize_markdown(
         yield " | ".join(["-" * len(str(item)) for item in headers])
 
     for item in data:
-        row = [item[field] for field in headers]
-        yield " | ".join([escape_pipes(escape_whitespace(str(item))) for item in row])
+        row = [
+            escape_pipes(escape_whitespace(str(item.get(field, ""))))
+            for field in headers
+        ]
+        yield " | ".join(row) or "<no data>"
 
 
 RELATIVE_RE = re.compile(r"(\d+)([hdw])", re.IGNORECASE)


### PR DESCRIPTION
If the user requests a field that they don't have permission to access, it used to kick up an exception. Now it spits out `"<no data>"`.

Fixes #61