### PR TITLE
Fix fetch-data to work with new raw crash structure

### DIFF
--- a/src/crashstats_tools/cmd_fetch_data.py
+++ b/src/crashstats_tools/cmd_fetch_data.py
@@ -56,7 +56,7 @@ def fetch_crash(
 
         if fetchdumps:
             # Save dump_names to file system
-            dump_names = raw_crash.get("dump_checksums", {}).keys()
+            dump_names = raw_crash.get("metadata", {}).get("dump_checksums", {}).keys()
             fn = os.path.join(outputdir, "dump_names", crash_id)
             create_dir_if_needed(os.path.dirname(fn))
             with open(fn, "w") as fp:
@@ -255,7 +255,7 @@ def fetch_data(
             console=console,
             host=host,
             fetchraw=fetchraw,
-            fetchdumps=fetchdumps if api_token else False,
+            fetchdumps=fetchdumps,
             fetchprocessed=fetchprocessed,
             outputdir=outputdir,
             api_token=api_token,

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -178,8 +178,10 @@ def test_fetch_dumps(tmpdir):
     raw_crash = {
         "ProductName": "Firefox",
         "Version": "100.0",
-        "dump_checksums": {
-            "upload_file_minidump": minidump_checksum,
+        "metadata": {
+            "dump_checksums": {
+                "upload_file_minidump": minidump_checksum,
+            },
         },
     }
 


### PR DESCRIPTION
This fixes fetch-data to work with the new raw crash structure which has collector-added data in a "metadata" structure.