### PR TITLE
Fix fetch-data to put raw crash in raw_crash/DATE/CRASHID (#66)

### DIFF
--- a/src/crashstats_tools/cmd_fetch_data.py
+++ b/src/crashstats_tools/cmd_fetch_data.py
@@ -30,12 +30,12 @@ def fetch_crash(
 ):
     """Fetch crash data and save to correct place on the file system
 
-    http://antenna.readthedocs.io/en/latest/architecture.html#aws-s3-file-hierarchy
+    https://antenna.readthedocs.io/en/latest/overview.html#aws-s3-file-hierarchy
 
     """
     if fetchraw:
-        # Fetch raw crash metadata
-        fn = os.path.join(outputdir, "raw_crash", crash_id)
+        # Fetch raw crash metadata to OUTPUTDIR/raw_crash/DATE/CRASHID
+        fn = os.path.join(outputdir, "raw_crash", "20" + crash_id[-6:], crash_id)
         if os.path.exists(fn) and not overwrite:
             console.print(
                 f"[bold green]Fetching raw {crash_id}[/bold green] ... already exists"
@@ -143,7 +143,7 @@ def fetch_crash(
 @click.option(
     "--dumps/--no-dumps",
     "fetchdumps",
-    default=True,
+    default=False,
     help="whether or not to save dumps",
 )
 @click.option(
@@ -183,15 +183,17 @@ def fetch_data(
     Crash data is split up into directories: raw_crash/, dump_names/,
     processed_crash/, and directories with the same name as the dump type.
 
+    https://antenna.readthedocs.io/en/latest/overview.html#aws-s3-file-hierarchy
+
     This requires an API token in order to download dumps, personally identifiable
     information, and security-sensitive data. It also reduces rate-limiting.  Set
     the CRASHSTATS_API_TOKEN environment variable to your API token value:
 
-        CRASHSTATS_API_TOKEN=xyz fetch-data crashdata ...
+    CRASHSTATS_API_TOKEN=xyz fetch-data crashdata ...
 
     To create an API token for Crash Stats, visit:
 
-        https://crash-stats.mozilla.org/api/tokens/
+    https://crash-stats.mozilla.org/api/tokens/
 
     Remember to abide by the data access policy when using data from Crash Stats!
     The policy is specified here:

--- a/src/crashstats_tools/cmd_reprocess.py
+++ b/src/crashstats_tools/cmd_reprocess.py
@@ -62,6 +62,10 @@ def reprocess(ctx, host, sleep, ruleset, allow_many, color, crashids):
     This requires CRASHSTATS_API_TOKEN to be set in the environment to a valid
     API token.
 
+    To create an API token for Crash Stats, visit:
+
+    https://crash-stats.mozilla.org/api/tokens/
+
     Note: If you're processing more than 10,000 crashes, you should use a sleep
     value that balances the rate of crash ids being added to the queue and the
     rate of crash ids being processed. For example, you could use "--sleep 10"

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -65,7 +65,9 @@ def test_fetch_raw(tmpdir):
         Done!
         """
     )
-    data = pathlib.Path(tmpdir / "raw_crash" / crash_id).read_bytes()
+    data = pathlib.Path(
+        tmpdir / "raw_crash" / f"20{crash_id[-6:]}" / crash_id
+    ).read_bytes()
     assert json.loads(data) == raw_crash
 
 
@@ -114,7 +116,9 @@ def test_fetch_raw_with_token(tmpdir):
         Done!
         """
     )
-    data = pathlib.Path(tmpdir / "raw_crash" / crash_id).read_bytes()
+    data = pathlib.Path(
+        tmpdir / "raw_crash" / f"20{crash_id[-6:]}" / crash_id
+    ).read_bytes()
     assert json.loads(data) == raw_crash
 
 
@@ -240,7 +244,9 @@ def test_fetch_dumps(tmpdir):
         Done!
         """
     )
-    data = pathlib.Path(tmpdir / "raw_crash" / crash_id).read_bytes()
+    data = pathlib.Path(
+        tmpdir / "raw_crash" / f"20{crash_id[-6:]}" / crash_id
+    ).read_bytes()
     assert json.loads(data) == raw_crash
 
     data = pathlib.Path(tmpdir / "upload_file_minidump" / crash_id).read_bytes()
@@ -387,5 +393,7 @@ def test_host(tmpdir):
         Done!
         """
     )
-    data = pathlib.Path(tmpdir / "raw_crash" / crash_id).read_bytes()
+    data = pathlib.Path(
+        tmpdir / "raw_crash" / f"20{crash_id[-6:]}" / crash_id
+    ).read_bytes()
     assert json.loads(data) == raw_crash


### PR DESCRIPTION
This changes fetch-data to put raw crash data in the directory tree in the place where socorro's crash storage puts it. It's kind of weird to do that, but it simplifies a bunch of socorro development to have tools using the same directory structure.

Fixes #66 