### PR TITLE
Add --denote-weekends (#54)

### DIFF
--- a/tests/test_supersearchfacet.py
+++ b/tests/test_supersearchfacet.py
@@ -235,6 +235,148 @@ def test_relative_date():
 
 @freezegun.freeze_time("2022-07-01 12:00:00")
 @responses.activate
+def test_denote_weekends():
+    supersearch_data = {
+        "hits": [],
+        "total": 837148,
+        "facets": {
+            "histogram_date": [
+                {
+                    "term": "2022-06-24T00:00:00+00:00",
+                    "count": 130824,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 62097},
+                            {"term": "Fenix", "count": 49585},
+                            {"term": "Thunderbird", "count": 18202},
+                            {"term": "Focus", "count": 938},
+                            {"term": "MozillaVPN", "count": 1},
+                            {"term": "ReferenceBrowser", "count": 1},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-25T00:00:00+00:00",
+                    "count": 129534,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 60180},
+                            {"term": "Fenix", "count": 49559},
+                            {"term": "Thunderbird", "count": 18888},
+                            {"term": "Focus", "count": 907},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-26T00:00:00+00:00",
+                    "count": 127166,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 59486},
+                            {"term": "Fenix", "count": 48276},
+                            {"term": "Thunderbird", "count": 18532},
+                            {"term": "Focus", "count": 871},
+                            {"term": "MozillaVPN", "count": 1},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-27T00:00:00+00:00",
+                    "count": 122340,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 55451},
+                            {"term": "Fenix", "count": 49019},
+                            {"term": "Thunderbird", "count": 16913},
+                            {"term": "Focus", "count": 957},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-28T00:00:00+00:00",
+                    "count": 99098,
+                    "facets": {
+                        "product": [
+                            {"term": "Fenix", "count": 49089},
+                            {"term": "Firefox", "count": 41220},
+                            {"term": "Thunderbird", "count": 7858},
+                            {"term": "Focus", "count": 931},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-29T00:00:00+00:00",
+                    "count": 96583,
+                    "facets": {
+                        "product": [
+                            {"term": "Fenix", "count": 50284},
+                            {"term": "Firefox", "count": 38363},
+                            {"term": "Thunderbird", "count": 7040},
+                            {"term": "Focus", "count": 895},
+                            {"term": "MozillaVPN", "count": 1},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-30T00:00:00+00:00",
+                    "count": 131603,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 62530},
+                            {"term": "Fenix", "count": 49355},
+                            {"term": "Thunderbird", "count": 18934},
+                            {"term": "Focus", "count": 784},
+                        ]
+                    },
+                },
+            ],
+        },
+    }
+
+    responses.add(
+        responses.GET,
+        DEFAULT_HOST + "/api/SuperSearch/",
+        match=[
+            responses.matchers.query_param_matcher(
+                {
+                    "_histogram.date": "product",
+                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "_results_number": "0",
+                }
+            ),
+        ],
+        status=200,
+        json=supersearch_data,
+    )
+    runner = CliRunner()
+    result = runner.invoke(
+        cli=cmd_supersearchfacet.supersearchfacet,
+        args=[
+            "--_histogram.date=product",
+            "--relative-range=7d",
+            "--denote-weekends",
+            "--format=tab",
+        ],
+        env={"COLUMNS": "100"},
+    )
+    assert result.exit_code == 0
+    assert result.output == dedent(
+        """\
+        product
+        histogram_date\t--\tFenix\tFirefox\tFocus\tMozillaVPN\tReferenceBrowser\tThunderbird\ttotal
+        2022-06-24\t0\t49585\t62097\t938\t1\t1\t18202\t130824
+        2022-06-25 **\t0\t49559\t60180\t907\t0\t0\t18888\t129534
+        2022-06-26 **\t0\t48276\t59486\t871\t1\t0\t18532\t127166
+        2022-06-27\t0\t49019\t55451\t957\t0\t0\t16913\t122340
+        2022-06-28\t0\t49089\t41220\t931\t0\t0\t7858\t99098
+        2022-06-29\t0\t50284\t38363\t895\t1\t0\t7040\t96583
+        2022-06-30\t0\t49355\t62530\t784\t0\t0\t18934\t131603
+        """
+    )
+
+
+@freezegun.freeze_time("2022-07-01 12:00:00")
+@responses.activate
 def test_supersearch_url():
     supersearch_data = {
         "hits": [],


### PR DESCRIPTION
This makes it easier to line up weekends and weekend lull in numbers.

Fixes #54

```
$ supersearchfacet --denote-weekends --_histogram.date=product
product
 histogram_date | -- | Fenix | Firefox | Focus | MozillaVPN | ReferenceBrowser | Thunderbird | total  
----------------|----|-------|---------|-------|------------|------------------|-------------|--------
 2023-10-03     | 0  | 49585 | 62097   | 938   | 1          | 1                | 18202       | 130824 
 2023-10-04     | 0  | 49559 | 60180   | 907   | 0          | 0                | 18888       | 129534 
 2023-10-05     | 0  | 48276 | 59486   | 871   | 1          | 0                | 18532       | 127166 
 2023-10-06     | 0  | 49019 | 55451   | 957   | 0          | 0                | 16913       | 122340 
 2023-10-07 **  | 0  | 49089 | 41220   | 931   | 0          | 0                | 7858        | 99098  
 2023-10-08 **  | 0  | 50284 | 38363   | 895   | 1          | 0                | 7040        | 96583  
 2023-10-09     | 0  | 49355 | 62530   | 784   | 0          | 0                | 18934       | 131603 
```