### PR TITLE
parallelize fetch-data (#106)

### DIFF
--- a/src/crashstats_tools/cmd_fetch_data.py
+++ b/src/crashstats_tools/cmd_fetch_data.py
@@ -164,6 +164,7 @@ def fetch_crash(
 @click.option(
     "--workers",
     default=1,
+    type=click.IntRange(1, 10, clamp=True),
     help="how many workers to use to download data; requires CRASHSTATS_API_TOKEN",
 )
 @click.option(
@@ -248,12 +249,14 @@ def fetch_data(
             + "information.[/yellow]"
         )
 
-    if workers > 1 and not api_token:
-        raise click.BadOptionUsage(
-            "workers",
-            "You must specify a CRASHSTATS_API_TOKEN in order to set workers > 1.",
-            ctx=ctx,
-        )
+    if workers > 1:
+        if not api_token:
+            raise click.BadOptionUsage(
+                "workers",
+                "You must specify a CRASHSTATS_API_TOKEN in order to set workers > 1.",
+                ctx=ctx,
+            )
+        console.print(f"Using {workers} workers.")
 
     if fetchdumps and not api_token:
         raise click.BadOptionUsage(

--- a/src/crashstats_tools/cmd_reprocess.py
+++ b/src/crashstats_tools/cmd_reprocess.py
@@ -11,7 +11,11 @@ import click
 from rich.console import Console
 from more_itertools import chunked
 
-from crashstats_tools.utils import DEFAULT_HOST, http_post, parse_crashid
+from crashstats_tools.utils import (
+    DEFAULT_HOST,
+    http_post,
+    parse_crash_id,
+)
 
 
 CHUNK_SIZE = 50
@@ -105,7 +109,7 @@ def reprocess(ctx, host, sleep, ruleset, allow_many, color, crashids):
     for crashid in crashids:
         crashid = crashid.strip()
         try:
-            crashid = parse_crashid(crashid).strip()
+            crashid = parse_crash_id(crashid).strip()
         except ValueError:
             console.print(f"[yellow]Crash id not recognized: {crashid}[/yellow]")
             continue

--- a/src/crashstats_tools/utils.py
+++ b/src/crashstats_tools/utils.py
@@ -312,8 +312,8 @@ def is_crash_id_valid(crash_id):
     return bool(CRASH_ID_RE.match(crash_id))
 
 
-def parse_crashid(item):
-    """Returns a crashid from a number of formats.
+def parse_crash_id(item):
+    """Returns a crash id from a number of formats.
 
     This handles the following three forms of crashids:
 
@@ -323,7 +323,7 @@ def parse_crashid(item):
 
     :arg str item: the thing to parse a crash id from
 
-    :returns: crashid as str or None
+    :returns: crash id as str or None
 
     :raises ValueError: if the crash id isn't recognized
 

--- a/tests/test_fetch_data.py
+++ b/tests/test_fetch_data.py
@@ -60,9 +60,7 @@ def test_fetch_raw(tmpdir):
         """\
         No api token provided. Set CRASHSTATS_API_TOKEN in the environment.
         Skipping dumps and personally identifiable information.
-        Working on 2ac9a763-83d2-4dca-89bb-091bd0220630...
-        Fetching raw 2ac9a763-83d2-4dca-89bb-091bd0220630
-        Done!
+        2ac9a763-83d2-4dca-89bb-091bd0220630: fetching raw crash
         """
     )
     data = pathlib.Path(
@@ -111,9 +109,7 @@ def test_fetch_raw_with_token(tmpdir):
     assert result.output == dedent(
         """\
         Using api token: 935exxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        Working on 2ac9a763-83d2-4dca-89bb-091bd0220630...
-        Fetching raw 2ac9a763-83d2-4dca-89bb-091bd0220630
-        Done!
+        2ac9a763-83d2-4dca-89bb-091bd0220630: fetching raw crash
         """
     )
     data = pathlib.Path(
@@ -138,7 +134,7 @@ def test_fetch_dumps_no_token(tmpdir):
         """\
         No api token provided. Set CRASHSTATS_API_TOKEN in the environment.
         Skipping dumps and personally identifiable information.
-        Usage: fetch-data [OPTIONS] OUTPUTDIR [CRASHIDS]...
+        Usage: fetch-data [OPTIONS] OUTPUTDIR [CRASH_IDS]...
         Try 'fetch-data --help' for help.
 
         Error: You cannot fetch dumps without providing an API token.
@@ -164,7 +160,7 @@ def test_fetch_dumps_no_raw(tmpdir):
     assert result.exit_code == 2
     assert result.output == dedent(
         """\
-        Usage: fetch-data [OPTIONS] OUTPUTDIR [CRASHIDS]...
+        Usage: fetch-data [OPTIONS] OUTPUTDIR [CRASH_IDS]...
         Try 'fetch-data --help' for help.
 
         Error: You cannot fetch dumps without also fetching the raw crash.
@@ -238,10 +234,8 @@ def test_fetch_dumps(tmpdir):
     assert result.output == dedent(
         """\
         Using api token: 935exxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        Working on 2ac9a763-83d2-4dca-89bb-091bd0220630...
-        Fetching raw 2ac9a763-83d2-4dca-89bb-091bd0220630
-        Fetching dump 2ac9a763-83d2-4dca-89bb-091bd0220630/upload_file_minidump
-        Done!
+        2ac9a763-83d2-4dca-89bb-091bd0220630: fetching raw crash
+        2ac9a763-83d2-4dca-89bb-091bd0220630: fetching dump: upload_file_minidump
         """
     )
     data = pathlib.Path(
@@ -288,9 +282,7 @@ def test_fetch_processed(tmpdir):
         """\
         No api token provided. Set CRASHSTATS_API_TOKEN in the environment.
         Skipping dumps and personally identifiable information.
-        Working on 2ac9a763-83d2-4dca-89bb-091bd0220630...
-        Fetching processed 2ac9a763-83d2-4dca-89bb-091bd0220630
-        Done!
+        2ac9a763-83d2-4dca-89bb-091bd0220630: fetching processed crash
         """
     )
     data = pathlib.Path(tmpdir / "processed_crash" / crash_id).read_bytes()
@@ -336,9 +328,7 @@ def test_fetch_processed_with_token(tmpdir):
     assert result.output == dedent(
         """\
         Using api token: 935exxxxxxxxxxxxxxxxxxxxxxxxxxxx
-        Working on 2ac9a763-83d2-4dca-89bb-091bd0220630...
-        Fetching processed 2ac9a763-83d2-4dca-89bb-091bd0220630
-        Done!
+        2ac9a763-83d2-4dca-89bb-091bd0220630: fetching processed crash
         """
     )
     data = pathlib.Path(tmpdir / "processed_crash" / crash_id).read_bytes()
@@ -388,9 +378,7 @@ def test_host(tmpdir):
         """\
         No api token provided. Set CRASHSTATS_API_TOKEN in the environment.
         Skipping dumps and personally identifiable information.
-        Working on 2ac9a763-83d2-4dca-89bb-091bd0220630...
-        Fetching raw 2ac9a763-83d2-4dca-89bb-091bd0220630
-        Done!
+        2ac9a763-83d2-4dca-89bb-091bd0220630: fetching raw crash
         """
     )
     data = pathlib.Path(

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,7 @@ from crashstats_tools.utils import (
     INFINITY,
     is_crash_id_valid,
     parse_args,
-    parse_crashid,
+    parse_crash_id,
     parse_relative_date,
     tableize_markdown,
     tableize_tab,
@@ -94,14 +94,14 @@ def test_parse_args(args, expected):
         ),
     ],
 )
-def test_parse_crashid(item, expected):
-    assert parse_crashid(item) == expected
+def test_parse_crash_id(item, expected):
+    assert parse_crash_id(item) == expected
 
 
 @pytest.mark.parametrize("item", ["", "foo"])
-def test_parse_crashid_badids(item):
+def test_parse_crash_id_badids(item):
     with pytest.raises(ValueError):
-        parse_crashid(item)
+        parse_crash_id(item)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
- Redo output for fetch-data (#106)
- Implement parallelization for fetch-data (#106)

This vastly improves `fetch-data` speed as it allows us to do something like this:

```
cat crashids.txt | fetch-data --workers=5 crashdata
```

It defaults to 1 worker (serial). It requires a `CRASHSTATS_API_TOKEN` for multiple workers. The output is a lot leaner and easier to read.