### PR TITLE
Switch to ruff for formatting (#113)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,12 @@ clean:  ## Clean build artifacts
 	find src tests/ -name __pycache__ | xargs rm -rf
 	find src tests/ -name '*.pyc' | xargs rm -rf
 
+.PHONY: format
+format:  ## Format files
+	tox exec -e py38-lint -- ruff format
+
 .PHONY: lint
-lint:  ## Lint and black reformat files
-	tox exec -e py38-lint -- black setup.py src tests
+lint:  ## Lint files
 	tox -e py38-lint
 
 .PHONY: test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,11 +14,6 @@ src = ["src"]
 docstring-quotes = "double"
 
 
-[tool.black]
-line-length = 88
-target-version = ["py38"]
-
-
 [tool.tox]
 legacy_tox_ini = """
 [tox]
@@ -47,6 +42,6 @@ commands =
 basepython = python3.8
 changedir = {toxinidir}
 commands =
-    black --check setup.py src tests
-    ruff setup.py src tests
+    ruff format --check setup.py src tests
+    ruff check setup.py src tests
 """

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,14 +1,13 @@
 -e .
 
-black==23.9.1
 build==1.0.3
 check-manifest==0.49
 cogapp==3.3.0
-freezegun==1.2.2
-pytest==7.4.2
-responses==0.23.3
-ruff==0.0.292
-tox==4.11.3
+freezegun==1.4.0
+pytest==7.4.3
+responses==0.24.1
+ruff==0.1.9
+tox==4.11.4
 tox-gh-actions==3.1.3
 twine==4.0.2
-wheel==0.41.2
+wheel==0.42.0

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
 import codecs
 import os
 import re


### PR DESCRIPTION
This switches from black to ruff for formatting Python files. It adds a new "format" make rule to run ruff on all Python files in the repository directory.

Fixes #113.