### PR TITLE
Fix --leftover-count for histograms (#126)

### DIFF
--- a/src/crashstats_tools/cmd_supersearchfacet.py
+++ b/src/crashstats_tools/cmd_supersearchfacet.py
@@ -434,7 +434,6 @@ def supersearchfacet(
         host=host,
         logger=ConsoleLogger(console) if verbose else None,
     )
-
     if (
         "signature" not in params["_facets"]
         and "signature" in facet_data_payload["facets"]
@@ -460,6 +459,20 @@ def supersearchfacet(
                 records.append({facet_name: "--", "count": total - record_sum})
 
             records.append({facet_name: "total", "count": total})
+
+        elif facet_name.startswith("histogram"):
+            if leftover_count:
+                for _, rows in records.items():
+                    for row in rows:
+                        count = 0
+                        for key, val in row.items():
+                            if key == facet_name:
+                                continue
+                            elif key == "total":
+                                count -= int(val)
+                            else:
+                                count += int(val)
+                        row["--"] = str(count)
 
     if format_type == "json":
         console.print_json(json.dumps(flattened_facets))

--- a/tests/test_supersearchfacet.py
+++ b/tests/test_supersearchfacet.py
@@ -922,6 +922,148 @@ def test_histogram_date_product():
 
 @freezegun.freeze_time("2022-07-01 12:00:00")
 @responses.activate
+def test_histogram_date_product_with_leftover():
+    supersearch_data = {
+        "hits": [],
+        "total": 837148,
+        "facets": {
+            "histogram_date": [
+                {
+                    "term": "2022-06-24T00:00:00+00:00",
+                    "count": 130824,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 62097},
+                            {"term": "Fenix", "count": 49585},
+                            {"term": "Thunderbird", "count": 18202},
+                            {"term": "Focus", "count": 938},
+                            {"term": "MozillaVPN", "count": 1},
+                            {"term": "ReferenceBrowser", "count": 1},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-25T00:00:00+00:00",
+                    "count": 129534,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 60180},
+                            {"term": "Fenix", "count": 49559},
+                            {"term": "Thunderbird", "count": 18888},
+                            {"term": "Focus", "count": 907},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-26T00:00:00+00:00",
+                    "count": 127166,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 59486},
+                            {"term": "Fenix", "count": 48276},
+                            {"term": "Thunderbird", "count": 18532},
+                            {"term": "Focus", "count": 871},
+                            {"term": "MozillaVPN", "count": 1},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-27T00:00:00+00:00",
+                    "count": 122340,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 55451},
+                            {"term": "Fenix", "count": 49019},
+                            {"term": "Thunderbird", "count": 16913},
+                            {"term": "Focus", "count": 957},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-28T00:00:00+00:00",
+                    "count": 99098,
+                    "facets": {
+                        "product": [
+                            {"term": "Fenix", "count": 49089},
+                            {"term": "Firefox", "count": 41220},
+                            {"term": "Thunderbird", "count": 7858},
+                            {"term": "Focus", "count": 931},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-29T00:00:00+00:00",
+                    "count": 96583,
+                    "facets": {
+                        "product": [
+                            {"term": "Fenix", "count": 50284},
+                            {"term": "Firefox", "count": 38363},
+                            {"term": "Thunderbird", "count": 7040},
+                            {"term": "Focus", "count": 895},
+                            {"term": "MozillaVPN", "count": 1},
+                        ]
+                    },
+                },
+                {
+                    "term": "2022-06-30T00:00:00+00:00",
+                    "count": 131603,
+                    "facets": {
+                        "product": [
+                            {"term": "Firefox", "count": 62530},
+                            {"term": "Fenix", "count": 49355},
+                            {"term": "Thunderbird", "count": 18934},
+                            {"term": "Focus", "count": 784},
+                        ]
+                    },
+                },
+            ],
+        },
+    }
+
+    responses.add(
+        responses.GET,
+        DEFAULT_HOST + "/api/SuperSearch/",
+        match=[
+            responses.matchers.query_param_matcher(
+                {
+                    "_histogram.date": "product",
+                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "_results_number": "0",
+                }
+            ),
+        ],
+        status=200,
+        json=supersearch_data,
+    )
+    runner = CliRunner(mix_stderr=False)
+    result = runner.invoke(
+        cli=cmd_supersearchfacet.supersearchfacet,
+        args=[
+            "--_histogram.date=product",
+            "--relative-range=1w",
+            "--format=tab",
+            "--leftover-count",
+        ],
+        env={"COLUMNS": "100"},
+    )
+    assert result.exit_code == 0
+    assert result.output == dedent(
+        """\
+        histogram_date.product
+        histogram_date\t--\tFenix\tFirefox\tFocus\tMozillaVPN\tReferenceBrowser\tThunderbird\ttotal
+        2022-06-24\t0\t49585\t62097\t938\t1\t1\t18202\t130824
+        2022-06-25\t0\t49559\t60180\t907\t0\t0\t18888\t129534
+        2022-06-26\t0\t48276\t59486\t871\t1\t0\t18532\t127166
+        2022-06-27\t0\t49019\t55451\t957\t0\t0\t16913\t122340
+        2022-06-28\t0\t49089\t41220\t931\t0\t0\t7858\t99098
+        2022-06-29\t0\t50284\t38363\t895\t1\t0\t7040\t96583
+        2022-06-30\t0\t49355\t62530\t784\t0\t0\t18934\t131603
+        """
+    )
+
+
+@freezegun.freeze_time("2022-07-01 12:00:00")
+@responses.activate
 def test_table():
     supersearch_data = {
         "hits": [],


### PR DESCRIPTION
This fixes `--leftover-count` for histograms. I'm not sure it provides a lot of value, but it's less weird that it's skipped.

```
$ supersearchfacet --_histogram.date=product --leftover-count
histogram_date.product
 histogram_date | -- | Fenix | Firefox | Focus | MozillaVPN | Thunderbird | total  
----------------|----|-------|---------|-------|------------|-------------|--------
 2024-04-05     | 0  | 25677 | 56172   | 518   | 0          | 13365       | 95732  
 2024-04-06     | 0  | 25330 | 40009   | 468   | 4          | 6204        | 72015  
 2024-04-07     | 0  | 26191 | 39600   | 508   | 0          | 6122        | 72421  
 2024-04-08     | 0  | 25038 | 63071   | 429   | 0          | 15283       | 103821 
 2024-04-09     | 0  | 25386 | 58655   | 522   | 1          | 14701       | 99265  
 2024-04-10     | 0  | 25120 | 60404   | 497   | 1          | 14951       | 100973 
 2024-04-11     | 0  | 24132 | 56894   | 536   | 0          | 14983       | 96545  
```

Fixes #126 