### PR TITLE
Remove irrelevant files from MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,8 +2,6 @@ include LICENSE
 include README.rst
 include HISTORY.rst
 include CODE_OF_CONDUCT.md
-include requirements-dev.txt
-include tox.ini
 include Makefile
 
 exclude tests


### PR DESCRIPTION
These files no longer exist, so they don't need to be in the MANIFEST.in file.