### PR TITLE
Fix end-date and start-date in supersearchfacet (#136)

### DIFF
--- a/src/crashstats_tools/cmd_supersearchfacet.py
+++ b/src/crashstats_tools/cmd_supersearchfacet.py
@@ -224,13 +224,23 @@ def fix_value(value, denote_weekends=False):
 )
 @click.option("--supersearch-url", default="", help="Super Search url to base query on")
 @click.option(
-    "--start-date", default="", help="start date for range; YYYY-MM-DD format"
+    "--start-date",
+    default="",
+    help=(
+        "start date for range; "
+        + "'YYYY-MM-DD' and 'YYYY-MM-DD HH:MM:SS' formats; "
+        + "defaults to 00:00:00 when no time specified"
+    ),
 )
 @click.option(
     "--end-date",
     default="today",
     show_default=True,
-    help="end date for range; YYYY-MM-DD format",
+    help=(
+        "end date for range; "
+        + "'YYYY-MM-DD' and 'YYYY-MM-DD HH:MM:SS' formats; "
+        + "defaults to 23:59:59 when no time specified"
+    ),
 )
 @click.option(
     "--relative-range", default="7d", help="relative range ending on end-date"
@@ -370,6 +380,9 @@ def supersearchfacet(
     """
     host = host.rstrip("/")
 
+    today = datetime.datetime.now()
+    yesterday = today - datetime.timedelta(days=1)
+
     if not color:
         console = Console(color_system=None, tab_size=None)
         console_err = Console(color_system=None, tab_size=None, stderr=True)
@@ -378,7 +391,9 @@ def supersearchfacet(
         console_err = Console(tab_size=None, stderr=True)
 
     if end_date == "today":
-        end_date = datetime.datetime.now().strftime("%Y-%m-%d")
+        end_date = today.strftime("%Y-%m-%d")
+    elif end_date == "yesterday":
+        end_date = yesterday.strftime("%Y-%m-%d")
 
     # Require at least one facet specified.
     parsed_args = parse_args(ctx.args)
@@ -423,6 +438,10 @@ def supersearchfacet(
         ).strftime("%Y-%m-%d")
 
     if "date" not in params:
+        if len(start_date) == 10:
+            start_date = f"{start_date} 00:00:00"
+        if len(end_date) == 10:
+            end_date = f"{end_date} 23:59:59"
         params.update({"date": [">=%s" % start_date, "<%s" % end_date]})
 
     if verbose:

--- a/tests/test_supersearchfacet.py
+++ b/tests/test_supersearchfacet.py
@@ -46,7 +46,7 @@ def test_host():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -96,7 +96,7 @@ def test_token():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -146,7 +146,7 @@ def test_dates():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=" + start_date, "<" + end_date],
+                    "date": [f">={start_date} 00:00:00", f"<{end_date} 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -199,7 +199,7 @@ def test_relative_date():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-28", "<2022-07-01"],
+                    "date": [">=2022-06-28 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -337,7 +337,7 @@ def test_denote_weekends():
             responses.matchers.query_param_matcher(
                 {
                     "_histogram.date": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -667,7 +667,7 @@ def test_facet_product():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -715,7 +715,7 @@ def test_facet_product_with_leftovers():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -759,7 +759,7 @@ def test_cardinality_product():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "_cardinality.product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -890,7 +890,7 @@ def test_histogram_date_product():
             responses.matchers.query_param_matcher(
                 {
                     "_histogram.date": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -1027,7 +1027,7 @@ def test_histogram_date_product_with_leftover():
             responses.matchers.query_param_matcher(
                 {
                     "_histogram.date": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -1084,7 +1084,7 @@ def test_table():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -1136,7 +1136,7 @@ def test_csv():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -1184,7 +1184,7 @@ def test_markdown():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),
@@ -1233,7 +1233,7 @@ def test_json():
             responses.matchers.query_param_matcher(
                 {
                     "_facets": "product",
-                    "date": [">=2022-06-24", "<2022-07-01"],
+                    "date": [">=2022-06-24 00:00:00", "<2022-07-01 23:59:59"],
                     "_results_number": "0",
                 }
             ),


### PR DESCRIPTION
This fixes end-date and start-date defaults to include time so that the default span includes all of today rather than up-to-but-not-including today.

Fixes #136.