### PR TITLE
Add download stats and estimate to fetch-data (#149)

### DIFF
--- a/tests/test_reprocess.py
+++ b/tests/test_reprocess.py
@@ -284,7 +284,6 @@ def test_reprocess_tenthousand_allowmany():
         """
         )
     )
-    print(result.output.splitlines()[-3:])
     assert result.output.endswith(
         dedent(
             f"""\

--- a/tests/test_supersearch.py
+++ b/tests/test_supersearch.py
@@ -249,7 +249,6 @@ def test_json():
         args=["--_columns=uuid", "--_columns=signature", "--format=json"],
         env={"COLUMNS": "100"},
     )
-    print(result.output)
     assert result.exit_code == 0
     assert result.output == dedent(
         """\

--- a/tests/test_supersearchfacet.py
+++ b/tests/test_supersearchfacet.py
@@ -412,7 +412,6 @@ def test_supersearch_url():
         ],
         env={"COLUMNS": "100"},
     )
-    print(result.output)
     assert result.exit_code == 0
     assert result.output == dedent(
         """\


### PR DESCRIPTION
This adds a `--stats` option to `fetch-data` that will show download stats and an estimate instead of the verbose log of what it downloaded.

With `--no-stats` (the default):

```bash
$ supersearch --num=105 | fetch-data --processed --no-raw --no-dumps --overwrite --workers=10 --no-stats crashdata
Using API token: xxx
Using 10 workers.
e96fe956-3c2f-4d58-b9b9-30d200240918: fetching processed crash
... CLIP ...
191c49a6-22a0-4d1f-a606-2c8f00240918: fetching processed crash
Completed in 0:00:05.
```

With `--stats``:

```bash
$ supersearch --num=105 | fetch-data --processed --no-raw --no-dumps --overwrite --workers=10 --stats crashdata
Using API token: xxx
Using 10 workers.
Downloaded (0/105) 0:00:52.308396
Downloaded (100/105) 0:00:00.514721
Completed in 0:00:08.
```